### PR TITLE
[G3000] Fix "NO WIND DATA" font size on PFD

### DIFF
--- a/src/workingtitle-vcockpits-instruments-navsystems-g3000/html_ui/WTg3000/Avionics/Shared/PFD/G3x5_PFDWindDataHTMLElement.js
+++ b/src/workingtitle-vcockpits-instruments-navsystems-g3000/html_ui/WTg3000/Avionics/Shared/PFD/G3x5_PFDWindDataHTMLElement.js
@@ -513,7 +513,7 @@ WT_G3x5_PFDWindDataHTMLElement.TEMPLATE.innerHTML = `
                     width: 100%;
                     transform: translateY(-50%);
                     text-align: center;
-                    font-size: var(--winddata-nodata-font-size, 1em);
+                    font-size: var(--winddata-nodata-font-size, 0.9em);
                 }
     </style>
     <div id="wrapper">


### PR DESCRIPTION
The font size was too big, so "DATA" actually ended up being printed on the top of the screen. Once the font size is adjusted the text is displayed in two rows, which is how it is on the Garmins.

Before:
![Before](https://user-images.githubusercontent.com/431167/112765078-1e7a2880-9014-11eb-84a8-7284c75244bb.jpg)
After:
![After](https://user-images.githubusercontent.com/431167/112765076-1de19200-9014-11eb-9a68-cc3ab897f410.jpg)
